### PR TITLE
Adding flexible auth via a .fauna config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "FaunaDB",
   "description": "FaunaDB extension",
   "icon": "media/faunadb-extension-logo.png",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "publisher": "fauna",
   "engines": {
     "vscode": "^1.40.0"

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,11 +3,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 function parseEnvironmentFile(src: string) {
-  // Try parse JSON
   try {
-    return JSON.parse(src.toString());
-  } catch (err) {
-    // Try parse envfile string
     const result: any = {};
     const lines = src.toString().split('\n');
     for (const line of lines) {
@@ -19,12 +15,14 @@ function parseEnvironmentFile(src: string) {
       }
     }
     return result;
+  } catch (error) {
+    console.error(`Error parsing FAUNA_KEY from .faunarc: ${error}`)
   }
 }
 
 export function getLocalKey(): string | undefined {
   const workspace = vscode.workspace.rootPath;
-  const localConfigPath = path.resolve(workspace as string, '.fauna');
+  const localConfigPath = path.resolve(workspace as string, '.faunarc');
   if (fs.existsSync(localConfigPath)) {
     const settings = parseEnvironmentFile(fs.readFileSync(localConfigPath).toString());
     return settings.FAUNA_KEY as string;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,33 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+function parseEnvironmentFile(src: string) {
+  // Try parse JSON
+  try {
+    return JSON.parse(src.toString());
+  } catch (err) {
+    // Try parse envfile string
+    const result: any = {};
+    const lines = src.toString().split('\n');
+    for (const line of lines) {
+      const match = line.match(/^([^=:#]+?)[=:](.*)/);
+      if (match) {
+        const key = match[1].trim();
+        const value = match[2].trim();
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+}
+
+export function getLocalKey(): string | undefined {
+  const workspace = vscode.workspace.rootPath;
+  const localConfigPath = path.resolve(workspace as string, '.fauna');
+  if (fs.existsSync(localConfigPath)) {
+    const settings = parseEnvironmentFile(fs.readFileSync(localConfigPath).toString());
+    return settings.KEY as string;
+  }
+  return;
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -27,7 +27,7 @@ export function getLocalKey(): string | undefined {
   const localConfigPath = path.resolve(workspace as string, '.fauna');
   if (fs.existsSync(localConfigPath)) {
     const settings = parseEnvironmentFile(fs.readFileSync(localConfigPath).toString());
-    return settings.KEY as string;
+    return settings.FAUNA_KEY as string;
   }
   return;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ export function activate(context: vscode.ExtensionContext) {
   const config = vscode.workspace.getConfiguration('faunadb');
   let adminSecretKey = config.get<string>('adminSecretKey');
   
-  // Load a local key if there is (in a .fauna file set as KEY=<your-secret>)
+  // Load a local key if there is (in a .fauna file set as FAUNA_KEY=<your-secret>)
   let localSecretKey = getLocalKey();
   if(localSecretKey) {
     adminSecretKey = localSecretKey;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ export function activate(context: vscode.ExtensionContext) {
   const config = vscode.workspace.getConfiguration('faunadb');
   let adminSecretKey = config.get<string>('adminSecretKey');
   
-  // Load a local key if there is (in a .fauna file set as FAUNA_KEY=<your-secret>)
+  // Load a local key if there is (in a .faunarc file set as FAUNA_KEY=<your-secret>)
   let localSecretKey = getLocalKey();
   if(localSecretKey) {
     adminSecretKey = localSecretKey;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import FaunaDBSchemaProvider from './FaunaDBSchemaProvider';
 import FQLContentProvider from './FQLContentProvider';
 import createRunQueryCommand from './runQueryCommand';
 import createCreateQueryCommand from './createQueryCommand';
+import { getLocalKey } from "./auth";
 
 export function activate(context: vscode.ExtensionContext) {
   // Set output channel to display FQL results
@@ -18,7 +19,10 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Check if there is a secret key
   const config = vscode.workspace.getConfiguration('faunadb');
-  const adminSecretKey = config.get<string>('adminSecretKey');
+  let adminSecretKey = config.get<string>('adminSecretKey');
+  
+  // Load a local key if there is (in a .fauna file set as KEY=<your-secret>)
+  adminSecretKey = getLocalKey();
 
   if (!adminSecretKey) {
     vscode.window.showErrorMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,10 @@ export function activate(context: vscode.ExtensionContext) {
   let adminSecretKey = config.get<string>('adminSecretKey');
   
   // Load a local key if there is (in a .fauna file set as KEY=<your-secret>)
-  adminSecretKey = getLocalKey();
+  let localSecretKey = getLocalKey();
+  if(localSecretKey) {
+    adminSecretKey = localSecretKey;
+  }
 
   if (!adminSecretKey) {
     vscode.window.showErrorMessage(


### PR DESCRIPTION
I find it quite frustrating to have only one main fauna key set for the whole editor.
As I work through several projects I'ld prefer to be able to use locally set keys.

That's why I dug into the extension (first time watching what a VSCode Ext is made off :P).

How my update work:
- if a .fauna file is found in the current open folder, override the adminSecretKey by the KEY=<your-secret>