### PR TITLE
FE-609 | fix: do not output Exists result as object

### DIFF
--- a/src/fql.ts
+++ b/src/fql.ts
@@ -1,4 +1,7 @@
 import { query, Client } from "faunadb";
+import {renderSpecialType} from './specialTypes'
+const prettier = require("prettier/standalone");
+const plugins = [require("prettier/parser-babylon")];
 
 export function evalFQLCode(code: string) {
   return baseEvalFQL(code, query);
@@ -219,5 +222,56 @@ export function runFQLQuery(code: string, client: Client) {
     return client.query(evalFQLCode(code));
   } catch (error) {
     return Promise.reject(error);
+  }
+}
+
+export function stringify(obj: object) {
+    const replacements: string[] = [];
+
+    let string = JSON.stringify(
+      obj,
+      (key, value) => {
+        const parsed = renderSpecialType(value);
+
+        if (parsed) {
+          const placeHolder =
+            "$$dash_replacement_$" + replacements.length + "$$";
+          replacements.push(parsed);
+          return placeHolder;
+        }
+
+        return value;
+      },
+      2
+    );
+
+    replacements.forEach((replace, index) => {
+      string = string.replace('"$$dash_replacement_$' + index + '$$"', replace);
+    });
+
+    if (string) {
+      string = string.replace(/\(null\)/g, "()");
+    }
+
+    return string;
+}
+
+export function formatFQLCode(code: object | string): string {
+  if (typeof code === "object") {
+    code = stringify(code);
+  }
+
+  try {
+    return prettier
+      .format(`(${code})`, {
+        parser: "babel",
+        plugins,
+      })
+      .trim()
+      .replace(/^(\({)/, "{")
+      .replace(/(}\);$)/g, "}")
+      .replace(";", "");
+  } catch (error) {
+    return code;
   }
 }

--- a/src/runQueryCommand.ts
+++ b/src/runQueryCommand.ts
@@ -43,18 +43,29 @@ export default (
   try {
     const result = await runFQLQuery(fqlExpression, client);
 
-    outputChannel.appendLine(
-      prettier
-        // @ts-ignore comment
-        .format(`(${Expr.toString(q.Object(result))})`, {
-          parser: 'babel',
-          plugins
-        })
-        .trim()
-        .replace(/^(\({)/, '{')
-        .replace(/(}\);$)/g, '}')
-        .replace(';', '')
-    );
+    typeof result === "object"
+      ? outputChannel.appendLine(
+          prettier
+            // @ts-ignore comment
+            .format(`(${Expr.toString(q.Object(result))})`, {
+              parser: "babel",
+              plugins,
+            })
+            .trim()
+            .replace(/^(\({)/, "{")
+            .replace(/(}\);$)/g, "}")
+            .replace(";", "")
+        )
+      : outputChannel.appendLine(
+          prettier
+            // @ts-ignore comment
+            .format(`(${Expr.toString(result)})`, {
+              parser: "babel",
+              plugins,
+            })
+            .trim()
+            .replace(";", "")
+        );
   } catch (error) {
     let message = error.message;
 

--- a/src/runQueryCommand.ts
+++ b/src/runQueryCommand.ts
@@ -1,6 +1,6 @@
 import vscode from 'vscode';
-import { Client, Expr, query as q, errors } from 'faunadb';
-import { runFQLQuery } from './fql';
+import { Client, errors } from 'faunadb';
+import { runFQLQuery, formatFQLCode } from './fql';
 const prettier = require('prettier/standalone');
 const plugins = [require('prettier/parser-babylon')];
 
@@ -42,30 +42,8 @@ export default (
 
   try {
     const result = await runFQLQuery(fqlExpression, client);
-
-    typeof result === "object"
-      ? outputChannel.appendLine(
-          prettier
-            // @ts-ignore comment
-            .format(`(${Expr.toString(q.Object(result))})`, {
-              parser: "babel",
-              plugins,
-            })
-            .trim()
-            .replace(/^(\({)/, "{")
-            .replace(/(}\);$)/g, "}")
-            .replace(";", "")
-        )
-      : outputChannel.appendLine(
-          prettier
-            // @ts-ignore comment
-            .format(`(${Expr.toString(result)})`, {
-              parser: "babel",
-              plugins,
-            })
-            .trim()
-            .replace(";", "")
-        );
+    const formattedCode = formatFQLCode(result);
+    outputChannel.appendLine(formattedCode)
   } catch (error) {
     let message = error.message;
 

--- a/src/specialTypes.ts
+++ b/src/specialTypes.ts
@@ -1,0 +1,73 @@
+// @ts-nocheck
+import { values as v, Expr } from "faunadb";
+
+const ctors = {
+  classes: "Class",
+  collections: "Collection",
+  indexes: "Index",
+  databases: "Database",
+  keys: "Key",
+  roles: "Role",
+};
+
+const parseRef = (obj) => {
+  if (obj === undefined) {
+    return obj;
+  } else if (obj instanceof v.Ref) {
+    return obj;
+  } else {
+    const ref = "@ref" in obj ? obj["@ref"] : obj;
+    return new v.Ref(ref.id, parseRef(ref.collection), parseRef(ref.database));
+  }
+};
+
+const renderRef = (obj) => {
+  let args = [`"${obj.id}"`];
+
+  if (obj.collection !== undefined) {
+    const ctor = ctors[obj.collection.id];
+    if (ctor !== undefined) {
+      if (obj.database !== undefined) args.push(renderRef(obj.database));
+      args = args.join(", ");
+      return `${ctor}(${args})`;
+    }
+  }
+
+  if (obj.collection !== undefined)
+    args = [renderRef(obj.collection)].concat(args);
+  args = args.join(", ");
+  return `Ref(${args})`;
+};
+
+export const renderSpecialType = (type) => {
+  if (!type) return null;
+
+  if (type instanceof v.Value) {
+    if (type instanceof v.Ref) return renderRef(type);
+    if (type instanceof v.FaunaTime) return `Time("${type.value}")`;
+    if (type instanceof v.FaunaDate) return `Date("${type.value}")`;
+    if (type instanceof v.Query) return `Query(${Expr.toString(type.value)})`;
+    return null;
+  }
+
+  if (typeof type === "object" && !Array.isArray(type)) {
+    const keys = Object.keys(type);
+
+    switch (keys[0]) {
+      case "@ref":
+        return renderRef(parseRef(type));
+      case "@ts":
+        return renderSpecialType(new v.FaunaTime(type["@ts"]));
+      case "@date":
+        return renderSpecialType(new v.FaunaDate(type["@date"]));
+      case "@code":
+        return type["@code"];
+      case "@query":
+        return renderSpecialType(new v.Query(type["@query"]));
+      default:
+        return null;
+    }
+  }
+
+  return null;
+};


### PR DESCRIPTION
### Notes
[Jira ticket](https://faunadb.atlassian.net/browse/FE-609)

Previously, when running the `Exists` function, users were getting an empty `{}` instead of a `true` or `false` return value. It seems we were assuming our return value would be an object and formatting it based on that. Now, if the return from `runFQLQuery` is not an object, we'll just stringify and output it.

**NOTE:** This also fixes an issue with string outputs like the example below, which is what currently happens on `master`:
```
LowerCase("HI THERE")
{ 0: "h", 1: "i", 2: " ", 3: "t", 4: "h", 5: "e", 6: "r", 7: "e" }
```

Closed #33 

### Screencap
https://www.loom.com/share/e0d1032fb0d84483b1d583bc5a8fc325