### PR TITLE
chore: upgrade to prettier v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,11 +163,11 @@
   "dependencies": {
     "@types/highlight.js": "^9.12.3",
     "@types/node-fetch": "^2.5.7",
-    "@types/prettier": "^1.19.0",
+    "@types/prettier": "^2.1.6",
     "faunadb": "git+https://github.com/fauna/faunadb-js.git#triage/bearer-to-basic",
     "highlight.js": "^9.16.2",
     "node-fetch": "^2.6.0",
-    "prettier": "^1.19.1",
+    "prettier": "^2.2.1",
     "vsce": "^1.73.0"
   }
 }

--- a/src/FQLContentProvider.ts
+++ b/src/FQLContentProvider.ts
@@ -1,6 +1,6 @@
 import vscode from 'vscode';
 const prettier = require('prettier/standalone');
-const plugins = [require('prettier/parser-babylon')];
+const plugins = [require('prettier/parser-meriyah')];
 
 export default class FQLContentProvider
   implements vscode.TextDocumentContentProvider {
@@ -9,10 +9,7 @@ export default class FQLContentProvider
 
   provideTextDocumentContent(uri: vscode.Uri): string {
     return prettier
-      .format(`(${uri.fragment})`, {
-        parser: 'babel',
-        plugins
-      })
+      .format(`(${uri.fragment})`, { parser: 'meriyah', plugins })
       .trim()
       .replace(/^(\({)/, '{')
       .replace(/(}\);$)/g, '}')

--- a/src/fql.ts
+++ b/src/fql.ts
@@ -1,7 +1,7 @@
 import { query, Client } from "faunadb";
 import {renderSpecialType} from './specialTypes'
 const prettier = require("prettier/standalone");
-const plugins = [require("prettier/parser-babylon")];
+const plugins = [require("prettier/parser-meriyah")];
 
 export function evalFQLCode(code: string) {
   return baseEvalFQL(code, query);
@@ -286,10 +286,7 @@ export function formatFQLCode(code: object | string): string {
 
   try {
     return prettier
-      .format(`(${code})`, {
-        parser: "babel",
-        plugins,
-      })
+      .format(`(${code})`, { parser: 'meriyah', plugins })
       .trim()
       .replace(/^(\({)/, "{")
       .replace(/(}\);$)/g, "}")

--- a/src/runQueryCommand.ts
+++ b/src/runQueryCommand.ts
@@ -1,8 +1,6 @@
 import vscode from 'vscode';
 import { Client, errors } from 'faunadb';
 import { runFQLQuery, formatFQLCode } from './fql';
-const prettier = require('prettier/standalone');
-const plugins = [require('prettier/parser-babylon')];
 
 export default (
   adminSecretKey: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,10 +60,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"
   integrity sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==
 
-"@types/prettier@^1.19.0":
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.0.tgz#a2502fb7ce9b6626fdbfc2e2a496f472de1bdd05"
-  integrity sha512-gDE8JJEygpay7IjA/u3JiIURvwZW08f0cZSZLAzFoX/ZmeqvS0Sqv+97aKuHpNsalAMMhwPe+iAS6fQbfmbt7A==
+"@types/prettier@^2.1.6":
+  version "2.1.6"
+  resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.6.tgz#f4b1efa784e8db479cdb8b14403e2144b1e9ff03"
+  integrity sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==
 
 "@types/vscode@^1.40.0":
   version "1.40.0"
@@ -929,10 +929,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 querystringify@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
The `parser-babylon` module was renamed to `parser-babel`, but I decided to use the `meriyah` parser instead, which is much faster: https://meriyah.github.io/meriyah/performance/