### PR TITLE
fix: faunadb to fauna

### DIFF
--- a/src/DocumentSchemaItem.ts
+++ b/src/DocumentSchemaItem.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
+import { Expr, query as q } from 'faunadb';
 import * as path from 'path';
-import { query as q, Expr } from 'faunadb';
-import { SchemaType } from './types';
+import * as vscode from 'vscode';
 import CollectionSchemaItem from './CollectionSchemaItem';
+import { SchemaType } from './types';
 
 export default class DocumentSchemaItem extends vscode.TreeItem {
   constructor(
@@ -12,6 +12,7 @@ export default class DocumentSchemaItem extends vscode.TreeItem {
     super(name);
   }
 
+  // @ts-ignore
   get tooltip(): string {
     return `${this.name}`;
   }
@@ -21,7 +22,7 @@ export default class DocumentSchemaItem extends vscode.TreeItem {
   }
 
   command = {
-    command: 'faunadb.open',
+    command: 'fauna.open',
     title: '',
     arguments: [this]
   };

--- a/src/FaunaSchemaProvider.ts
+++ b/src/FaunaSchemaProvider.ts
@@ -59,7 +59,7 @@ export default class FaunaSchemaProvider
 
   async query<T>(expr: Expr, parent?: DBSchemaItem | CollectionSchemaItem) {
     return vscode.commands.executeCommand(
-      'faunadb.query',
+      'fauna.query',
       expr,
       parent
     ) as Promise<T>;

--- a/src/FunctionSchemaItem.ts
+++ b/src/FunctionSchemaItem.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
+import { Expr, query as q } from 'faunadb';
 import * as path from 'path';
-import { query as q, Expr } from 'faunadb';
-import { SchemaType } from './types';
+import * as vscode from 'vscode';
 import DBSchemaItem from './DBSchemaItem';
+import { SchemaType } from './types';
 
 export default class FunctionSchemaItem extends vscode.TreeItem {
   constructor(
@@ -12,6 +12,7 @@ export default class FunctionSchemaItem extends vscode.TreeItem {
     super(name);
   }
 
+  // @ts-ignore
   get tooltip(): string {
     return `${this.name}`;
   }
@@ -21,7 +22,7 @@ export default class FunctionSchemaItem extends vscode.TreeItem {
   }
 
   command = {
-    command: 'faunadb.open',
+    command: 'fauna.open',
     title: '',
     arguments: [this]
   };

--- a/src/IndexSchemaItem.ts
+++ b/src/IndexSchemaItem.ts
@@ -12,6 +12,7 @@ export default class IndexSchemaItem extends vscode.TreeItem {
     super(name);
   }
 
+  // @ts-ignore
   get tooltip(): string {
     return `${this.name}`;
   }
@@ -21,7 +22,7 @@ export default class IndexSchemaItem extends vscode.TreeItem {
   }
 
   command = {
-    command: 'faunadb.open',
+    command: 'fauna.open',
     title: '',
     arguments: [this]
   };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,27 +85,29 @@ export function activate(context: vscode.ExtensionContext) {
         uploadGraphqlSchemaCommand('override', config, outputChannel)
       ),
       vscode.commands.registerCommand(
-        'faunadb.query',
+        'fauna.query',
         (expr: Expr, scope?: DBSchemaItem | CollectionSchemaItem) =>
           client.query(expr, {
             secret: mountSecret(scope)
           })
       ),
-      vscode.commands.registerCommand('faunadb.open', (item: SchemaItem) => {
+      vscode.commands.registerCommand('fauna.open', (item: SchemaItem) => {
         client
           .query<any>(item.content!, {
             secret: mountSecret(item.parent)
           })
           .then(async content => {
-            const uri = vscode.Uri.parse(
-              // @ts-ignore comment
-              `fqlcode:${item.name}#${Expr.toString(q.Object(content))}`
-            );
+            const str = `fqlcode:${item.name}#${Expr.toString(
+              q.Object(content)
+            )}`;
+            const uri = vscode.Uri.parse(str);
             const doc = await vscode.workspace.openTextDocument(uri); // calls back into the provider
             await vscode.window.showTextDocument(doc, { preview: false });
             vscode.languages.setTextDocumentLanguage(doc, 'javascript');
           })
-          .catch(console.error);
+          .catch(err => {
+            console.error(err);
+          });
       }),
       vscode.commands.registerCommand('fauna.refreshEntry', () =>
         faunaSchemaProvider.refresh()


### PR DESCRIPTION
After merging some community PR, we have leftovers of  `faunadb.*` commands that has been renamed