### PR TITLE
feature: add graphqlDomain setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Additionally config might have optional parameters
 FAUNA_DOMAIN=db.fauna.com
 FAUNA_SCHEME=https
 FAUNA_PORT=443
+FAUNA_GRAPHQL_DOMAIN=graphql.fauna.com
 ```
 
 #### Using VS Code to store a global key
@@ -58,6 +59,7 @@ FAUNA_PORT=443
 - `fauna.domain`: The hostname of endpoint’s Fauna instance
 - `fauna.scheme`: One of https or http
 - `fauna.port`: The UNIX port number of endpoint’s Fauna instance
+- `fauna.graphqlDomain`: The hostname of Fauna GraphQL API
 
 > WARNING: Be careful! To avoid exposing this secret, do not commit it to your local `.vscode` configuration.
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
           "type": "number",
           "default": 443,
           "description": "Optional - The UNIX port number of endpoint’s Fauna instance. Defaults to 443"
+        },
+        "fauna.graphqlDomain": {
+          "type": "string",
+          "default": "graphql.fauna.com",
+          "description": "Optional - The hostname of endpoint’s Fauna GraphQL API. Defaults to graphql.fauna.com"
         }
       }
     },

--- a/src/FaunaSchemaProvider.ts
+++ b/src/FaunaSchemaProvider.ts
@@ -21,7 +21,7 @@ export default class FaunaSchemaProvider
     ._onDidChangeTreeData.event;
 
   refresh(): void {
-    this._onDidChangeTreeData.fire({});
+    this._onDidChangeTreeData.fire(undefined);
   }
 
   getTreeItem(element: vscode.TreeItem): vscode.TreeItem {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ export interface Config {
   scheme?: 'http' | 'https';
   domain?: string;
   port?: number;
+  graphQLDomain?: string;
 }
 
 export function loadConfig(): Config {
@@ -22,12 +23,18 @@ export function loadConfig(): Config {
   const domain = env.FAUNA_DOMAIN || config.get('domain');
   const scheme = env.FAUNA_SCHEME || config.get('scheme');
   const port = env.FAUNA_PORT || config.get('port');
+  // should be explicitly set to a default value as this used to format endpoints and doesn't pass to faunadb-js driver
+  const graphQLDomain =
+    env.FAUNA_GRAPHQL_DOMAIN ||
+    config.get('graphqlDomain') ||
+    'graphql.fauna.com/';
 
   return {
     secret,
     ...(!!scheme && { scheme }),
     ...(domain && { domain }),
-    ...(port && { port })
+    ...(port && { port }),
+    ...(graphQLDomain && { graphQLDomain })
   };
 }
 
@@ -36,6 +43,7 @@ interface Env {
   FAUNA_SCHEME?: 'http' | 'https';
   FAUNA_DOMAIN?: string;
   FAUNA_PORT?: number;
+  FAUNA_GRAPHQL_DOMAIN?: string;
 }
 
 function loadEnvironmentFile() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,7 @@ export function loadConfig(): Config {
   const graphQLDomain =
     env.FAUNA_GRAPHQL_DOMAIN ||
     config.get('graphqlDomain') ||
-    'graphql.fauna.com/';
+    'graphql.fauna.com';
 
   return {
     secret,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,10 @@ export function activate(context: vscode.ExtensionContext) {
   function register() {
     const config = loadConfig();
     const client = new Client({
-      ...config,
+      secret: config.secret,
+      domain: config.domain,
+      scheme: config.scheme,
+      port: config.port,
       headers: {
         'X-Fauna-Source': 'VSCode'
       }

--- a/src/uploadGraphqlSchemaCommand.ts
+++ b/src/uploadGraphqlSchemaCommand.ts
@@ -1,5 +1,5 @@
-import vscode from 'vscode';
 import fetch from 'node-fetch';
+import vscode from 'vscode';
 import { Config } from './config';
 
 export default (
@@ -39,7 +39,7 @@ export default (
   try {
     const buffer = Buffer.from(fqlExpression, 'utf-8');
     const result = await fetch(
-      `https://graphql.fauna.com/import?mode=${mode}`,
+      `https://${config.graphQLDomain}/import?mode=${mode}`,
       {
         method: 'POST',
         headers: {


### PR DESCRIPTION
[OSS-653 Plugin does not provide the setting for GraphQL API endpoint](https://faunadb.atlassian.net/browse/OSS-653)

The VS Code plugin provides configuration for the secret, domain, port, and scheme, which is great if you're using a local Fauna DEV Docker image.

However, there is no configuration item available for the GraphQL API endpoint. It seems only the production GraphQL API is supported, not local or Preview.

![image](https://user-images.githubusercontent.com/12122603/116353153-f6423d00-a7fe-11eb-80b0-f2d57c6fe8b3.png)
