### PR TITLE
feature(configuration): graphql endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Additionally config might have optional parameters
 FAUNA_DOMAIN=db.fauna.com
 FAUNA_SCHEME=https
 FAUNA_PORT=443
-FAUNA_GRAPHQL_DOMAIN=graphql.fauna.com
+FAUNA_GRAPHQL_HOST=graphql.fauna.com
 ```
 
 #### Using VS Code to store a global key
@@ -59,7 +59,7 @@ FAUNA_GRAPHQL_DOMAIN=graphql.fauna.com
 - `fauna.domain`: The hostname of endpoint’s Fauna instance
 - `fauna.scheme`: One of https or http
 - `fauna.port`: The UNIX port number of endpoint’s Fauna instance
-- `fauna.graphqlEndpoint`: The hostname of Fauna GraphQL API
+- `fauna.graphqlHost`: The hostname of Fauna GraphQL API
 
 > WARNING: Be careful! To avoid exposing this secret, do not commit it to your local `.vscode` configuration.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ FAUNA_GRAPHQL_DOMAIN=graphql.fauna.com
 - `fauna.domain`: The hostname of endpoint’s Fauna instance
 - `fauna.scheme`: One of https or http
 - `fauna.port`: The UNIX port number of endpoint’s Fauna instance
-- `fauna.graphqlDomain`: The hostname of Fauna GraphQL API
+- `fauna.graphqlEndpoint`: The hostname of Fauna GraphQL API
 
 > WARNING: Be careful! To avoid exposing this secret, do not commit it to your local `.vscode` configuration.
 

--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
           "default": 443,
           "description": "Optional - The UNIX port number of endpoint’s Fauna instance. Defaults to 443"
         },
-        "fauna.graphqlDomain": {
+        "fauna.graphqlEndpoint": {
           "type": "string",
-          "default": "graphql.fauna.com",
-          "description": "Optional - The hostname of endpoint’s Fauna GraphQL API. Defaults to graphql.fauna.com"
+          "default": "https://graphql.fauna.com",
+          "description": "Optional - The Fauna GraphQL API endpoint. Defaults to https://graphql.fauna.com"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
           "default": 443,
           "description": "Optional - The UNIX port number of endpoint’s Fauna instance. Defaults to 443"
         },
-        "fauna.graphqlEndpoint": {
+        "fauna.graphqlHost": {
           "type": "string",
           "default": "https://graphql.fauna.com",
-          "description": "Optional - The Fauna GraphQL API endpoint. Defaults to https://graphql.fauna.com"
+          "description": "Optional - The Fauna GraphQL API host. Defaults to https://graphql.fauna.com"
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export interface Config {
   scheme?: 'http' | 'https';
   domain?: string;
   port?: number;
-  graphQLDomain?: string;
+  graphQLEndpoint?: string;
 }
 
 export function loadConfig(): Config {
@@ -24,17 +24,17 @@ export function loadConfig(): Config {
   const scheme = env.FAUNA_SCHEME || config.get('scheme');
   const port = env.FAUNA_PORT || config.get('port');
   // should be explicitly set to a default value as this used to format endpoints and doesn't pass to faunadb-js driver
-  const graphQLDomain =
+  const graphQLEndpoint =
     env.FAUNA_GRAPHQL_DOMAIN ||
-    config.get('graphqlDomain') ||
-    'graphql.fauna.com';
+    config.get('graphQLEndpoint') ||
+    'https://graphql.fauna.com';
 
   return {
     secret,
     ...(!!scheme && { scheme }),
     ...(domain && { domain }),
     ...(port && { port }),
-    ...(graphQLDomain && { graphQLDomain })
+    ...(graphQLEndpoint && { graphQLEndpoint })
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export interface Config {
   scheme?: 'http' | 'https';
   domain?: string;
   port?: number;
-  graphQLEndpoint?: string;
+  graphqlHost?: string;
 }
 
 export function loadConfig(): Config {
@@ -24,9 +24,9 @@ export function loadConfig(): Config {
   const scheme = env.FAUNA_SCHEME || config.get('scheme');
   const port = env.FAUNA_PORT || config.get('port');
   // should be explicitly set to a default value as this used to format endpoints and doesn't pass to faunadb-js driver
-  const graphQLEndpoint =
-    env.FAUNA_GRAPHQL_DOMAIN ||
-    config.get('graphQLEndpoint') ||
+  const graphqlHost =
+    env.FAUNA_GRAPHQL_HOST ||
+    config.get('graphqlHost') ||
     'https://graphql.fauna.com';
 
   return {
@@ -34,7 +34,7 @@ export function loadConfig(): Config {
     ...(!!scheme && { scheme }),
     ...(domain && { domain }),
     ...(port && { port }),
-    ...(graphQLEndpoint && { graphQLEndpoint })
+    ...(graphqlHost && { graphqlHost })
   };
 }
 
@@ -43,7 +43,7 @@ interface Env {
   FAUNA_SCHEME?: 'http' | 'https';
   FAUNA_DOMAIN?: string;
   FAUNA_PORT?: number;
-  FAUNA_GRAPHQL_DOMAIN?: string;
+  FAUNA_GRAPHQL_HOST?: string;
 }
 
 function loadEnvironmentFile() {

--- a/src/uploadGraphqlSchemaCommand.ts
+++ b/src/uploadGraphqlSchemaCommand.ts
@@ -39,7 +39,7 @@ export default (
   try {
     const buffer = Buffer.from(fqlExpression, 'utf-8');
     const result = await fetch(
-      `https://${config.graphQLDomain}/import?mode=${mode}`,
+      `${config.graphQLEndpoint}/import?mode=${mode}`,
       {
         method: 'POST',
         headers: {

--- a/src/uploadGraphqlSchemaCommand.ts
+++ b/src/uploadGraphqlSchemaCommand.ts
@@ -38,17 +38,14 @@ export default (
 
   try {
     const buffer = Buffer.from(fqlExpression, 'utf-8');
-    const result = await fetch(
-      `${config.graphQLEndpoint}/import?mode=${mode}`,
-      {
-        method: 'POST',
-        headers: {
-          AUTHORIZATION: `Bearer ${config.secret}`
-        },
+    const result = await fetch(`${config.graphqlHost}/import?mode=${mode}`, {
+      method: 'POST',
+      headers: {
+        AUTHORIZATION: `Bearer ${config.secret}`
+      },
 
-        body: buffer
-      }
-    );
+      body: buffer
+    });
     outputChannel.appendLine('');
     outputChannel.appendLine('RESPONSE:');
     outputChannel.appendLine(await result.text());


### PR DESCRIPTION
While the "domain" can be used to set the hostname and port, you cannot set the scheme. Fauna Dev doesn't run HTTPS because it would need to do some SSL key generation.

To connect to Fauna Dev via the VS Code extension, users would need to set http://localhost:8443/. If users do set that, then the extension attempts to connect to https://http//localhost:8443

Potentially, using the scheme field to compose the URL might be suitable.

![image](https://user-images.githubusercontent.com/12122603/116656804-faed2980-a995-11eb-8702-cb0edde9341b.png)
