### PR TITLE
fix: check graphql shema file extension

### DIFF
--- a/src/uploadGraphqlSchemaCommand.ts
+++ b/src/uploadGraphqlSchemaCommand.ts
@@ -9,11 +9,19 @@ export default (
 ) => async () => {
   const { activeTextEditor } = vscode.window;
 
-  if (!activeTextEditor || activeTextEditor.document.languageId !== 'graphql') {
-    vscode.window.showWarningMessage(
+  const fileName = activeTextEditor?.document.fileName.split('.') || [];
+
+  if (!activeTextEditor || !['graphql', 'gql'].includes(fileName[1])) {
+    vscode.window.showErrorMessage(
       'You must select a Graphql document (`.graphql` or `.gql`) to upload a schema.'
     );
     return;
+  }
+
+  if (activeTextEditor.document.languageId !== 'graphql') {
+    vscode.window.showWarningMessage(
+      'We recommend to install vscode-graphql extension for syntax highlighting, validation, and language features like go to definition, hover information and autocompletion for graphql projects'
+    );
   }
 
   const selection = activeTextEditor.selection;


### PR DESCRIPTION
GraphQL import command doesn't work as it checks languageId property of a document. If some graphql extension isn't installed it would be undefined which interrupts the upload schema.