### PR TITLE
multiline comment regex pattern

### DIFF
--- a/syntaxes/fql.tmLanguage
+++ b/syntaxes/fql.tmLanguage
@@ -152,6 +152,47 @@
 			</array>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>(^[ \t]+)?(?=/\*)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.whitespace.comment.leading.fql</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?!\G)((?!^)[ \t]+\*/)?</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.whitespace.comment.trailing.fql</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>/\*</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.comment.fql</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\*/</string>
+					<key>name</key>
+					<string>comment.line.octothorpe.fql</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
 			<key>match</key>
 			<string>\b(If|Else|And|Or|For)\b</string>
 			<key>name</key>


### PR DESCRIPTION
Highlighting for `//` comments works, a change made possible by recent versions, but not for multiline `/* ... */` which is pretty standard in multiple languages using `//`. This pull request enables it. By the way I don't know anything about tmLanguage, this duplicates the `//` code, switching it for multiline regex... so excuse me if it is not a performant way to handle this.

That said, even for `//` the extension doesn't allow running queries with comments inside it, so I use a regex (`//.+`) to remove them before running a query... Yet `//` comments are allowed in the Fauna dashboard shell. That should probably be an issue by itself.