### PR TITLE
Upate vs code marketplace token in the release pipeline

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -20,4 +20,4 @@ jobs:
       - task: publish
         file: fauna-vscode-repository/concourse/tasks/publish.yml
         params:
-          VSCE_PAT: ((vscode-marketplace-token))
+          VSCE_PAT: ((vscode-marketplace-token-v2))

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -20,4 +20,4 @@ jobs:
       - task: publish
         file: fauna-vscode-repository/concourse/tasks/publish.yml
         params:
-          VSCE_PAT: ((vscode-marketplace-token-v2))
+          VSCE_PAT: ((vscode-marketplace-token_expires-07/23))

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -20,4 +20,4 @@ jobs:
       - task: publish
         file: fauna-vscode-repository/concourse/tasks/publish.yml
         params:
-          VSCE_PAT: ((vscode-marketplace-token_expires-07/23))
+          VSCE_PAT: ((vscode-marketplace-token_expires-2023_06_29))

--- a/concourse/set-pipeline.sh
+++ b/concourse/set-pipeline.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# update the concourse pipeline with this script.
+
+fly -t faunadb set-pipeline --pipeline vscode-extension-release --config concourse/pipeline.yml


### PR DESCRIPTION
The VS code marketplace token that allows the pipeline to publish the extension was expired. I've generated a new token and put it in vault. This PR updates the pipeline to use the new token.